### PR TITLE
Created extension methods for consuming Swagger

### DIFF
--- a/dwCheckApi/ConfigureContainerExtenstions.cs
+++ b/dwCheckApi/ConfigureContainerExtenstions.cs
@@ -1,8 +1,12 @@
-﻿using dwCheckApi.Common;
+﻿using System.IO;
+using dwCheckApi.Common;
 using dwCheckApi.DAL;
+using dwCheckApi.Helpers;
 using dwCheckApi.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.PlatformAbstractions;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace dwCheckApi
 {
@@ -44,6 +48,57 @@ namespace dwCheckApi
                         .AllowAnyMethod()
                         .AllowAnyHeader()
                         .AllowCredentials());
+            });
+        }
+
+        /// <summary>
+        /// Used to register and add the Swagger generator to the service Colelction
+        /// </summary>
+        /// <param name="serviceCollection">
+        /// The <see cref="IServiceCollection"/> which is used in the Containter
+        /// </param>
+        /// <param name="includeXmlDocumentation">
+        /// Whether or not to include XmlDocumentation (defaults to True)
+        /// </param>
+        /// <remarks>
+        /// <param name="includeXmlDocumentation"/> requries:
+        ///   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        ///     <DocumentationFile>bin\Debug\netcoreapp2.0\dwCheckApi.xml</DocumentationFile>
+        ///  </PropertyGroup>
+        /// for debug builds and:
+        ///   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        ///     <DocumentationFile>bin\Release\netcoreapp2.0\dwCheckApi.xml</DocumentationFile>
+        ///  </PropertyGroup>
+        /// </remarks>
+        public static void AddSwagger(this IServiceCollection serviceCollection,
+            bool includeXmlDocumentation = true)
+        {
+            // Register the Swagger generator, defining one or more Swagger documents
+            serviceCollection.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc($"v{CommonHelpers.GetVersionNumber()}",
+                    new Info
+                    {
+                        Title = "dwCheckApi",
+                        Version = $"v{CommonHelpers.GetVersionNumber()}",
+                        Description = "A simple APi to get the details on Books, Characters and Series within a canon of novels",
+                        Contact = new Contact
+                        {
+                            Name = "Jamie Taylor",
+                            Email = "",
+                            Url = "https://dotnetcore.gaprogman.com"
+                        }
+                    }
+                );
+                
+                if (!includeXmlDocumentation) return;
+                // Set the comments path for the Swagger JSON and UI.
+                var basePath = PlatformServices.Default.Application.ApplicationBasePath;
+                var xmlPath = Path.Combine(basePath, "dwCheckApi.xml");
+                if (File.Exists(xmlPath))
+                {
+                    c.IncludeXmlComments(xmlPath);
+                }
             });
         }
     }

--- a/dwCheckApi/ConfigureContainerExtenstions.cs
+++ b/dwCheckApi/ConfigureContainerExtenstions.cs
@@ -57,6 +57,7 @@ namespace dwCheckApi
         /// <param name="serviceCollection">
         /// The <see cref="IServiceCollection"/> which is used in the Containter
         /// </param>
+        /// <param name="versionNumberString">The version number for the application</param>
         /// <param name="includeXmlDocumentation">
         /// Whether or not to include XmlDocumentation (defaults to True)
         /// </param>
@@ -70,7 +71,7 @@ namespace dwCheckApi
         ///     <DocumentationFile>bin\Release\netcoreapp2.0\dwCheckApi.xml</DocumentationFile>
         ///  </PropertyGroup>
         /// </remarks>
-        public static void AddSwagger(this IServiceCollection serviceCollection,
+        public static void AddSwagger(this IServiceCollection serviceCollection, string versionNumberString,
             bool includeXmlDocumentation = true)
         {
             // Register the Swagger generator, defining one or more Swagger documents

--- a/dwCheckApi/ConfigureHttpPipelineExtentions.cs
+++ b/dwCheckApi/ConfigureHttpPipelineExtentions.cs
@@ -43,5 +43,27 @@ namespace dwCheckApi
                 return context.EnsureSeedData();
             }
         }
+
+        /// <summary>
+        /// Used to tell the <see cref="IApplicationBuilder"/> to use Swagger and the Swagger UI
+        /// </summary>
+        /// <param name="applicationBuilder">
+        /// The <see cref="IApplicationBuilder"/> which is used in the Http Pipeline
+        /// </param>
+        /// <param name="swaggerUrl">The URL for the Swagger endpoint</param>
+        /// <param name="swaggerDescription">The description for the Swagger endpoint</param>
+        public static void UseSwagger(this IApplicationBuilder applicationBuilder,
+            string swaggerUrl, string swaggerDescription)
+        {
+            // Enable middleware to serve generated Swagger as a JSON endpoint.
+            applicationBuilder.UseSwagger();
+
+            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), specifying
+            // the Swagger JSON endpoint.
+            applicationBuilder.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint(swaggerUrl, swaggerDescription);
+            });
+        }
     }
 }

--- a/dwCheckApi/startup.cs
+++ b/dwCheckApi/startup.cs
@@ -39,7 +39,7 @@ namespace dwCheckApi
             services.AddCorsPolicy();
             services.AddDbContext();
             services.AddTransientServices();
-            services.AddSwagger();
+            services.AddSwagger($"v{CommonHelpers.GetVersionNumber()}");
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/dwCheckApi/startup.cs
+++ b/dwCheckApi/startup.cs
@@ -39,29 +39,7 @@ namespace dwCheckApi
             services.AddCorsPolicy();
             services.AddDbContext();
             services.AddTransientServices();
-            
-            // Register the Swagger generator, defining one or more Swagger documents
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc($"v{CommonHelpers.GetVersionNumber()}",
-                    new Info
-                    {
-                        Title = "dwCheckApi",
-                        Version = $"v{CommonHelpers.GetVersionNumber()}",
-                        Description = "A simple APi to get the details on Books, Characters and Series within a canon of novels",
-                        Contact = new Contact
-                        {
-                            Name = "Jamie Taylor",
-                            Email = "",
-                            Url = "https://dotnetcore.gaprogman.com"
-                        }
-                    }
-                );
-                // Set the comments path for the Swagger JSON and UI.
-                var basePath = PlatformServices.Default.Application.ApplicationBasePath;
-                var xmlPath = Path.Combine(basePath, "dwCheckApi.xml"); 
-                c.IncludeXmlComments(xmlPath); 
-            });
+            services.AddSwagger();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -78,15 +56,8 @@ namespace dwCheckApi
             app.UseCorsPolicy();
             app.UseStaticFiles();
             
-            // Enable middleware to serve generated Swagger as a JSON endpoint.
-            app.UseSwagger();
-
-            // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), specifying the Swagger JSON endpoint.
-            app.UseSwaggerUI(c =>
-            {
-                c.SwaggerEndpoint($"/swagger/v{CommonHelpers.GetVersionNumber()}/swagger.json",
-                    $"dwCheckApi {CommonHelpers.GetVersionNumber()}");
-            });
+            app.UseSwagger($"/swagger/v{CommonHelpers.GetVersionNumber()}/swagger.json",
+                $"dwCheckApi {CommonHelpers.GetVersionNumber()}");
             
             app.UseCustomisedMvc();
         }


### PR DESCRIPTION
`ConfigureContainterExtensions` now has a method called `AddSwagger` which adds Swagger to the Container.

`ConfigureHttpPipeLineExtensions` now has a method called `UseSwagger` which sets up Swagger for the Http Pipeline.

